### PR TITLE
Fix LetsEncrypt root certs in firstboot.d

### DIFF
--- a/firstboot.d/tailscale.sh
+++ b/firstboot.d/tailscale.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+sed -i 's|^mozilla\/DST_Root_CA_X3\.crt|!mozilla/DST_Root_CA_X3.crt|' /etc/ca-certificates.conf
+curl -sk https://letsencrypt.org/certs/isrgrootx1.pem -o /usr/local/share/ca-certificates/ISRG_Root_X1.crt
+update-ca-certificates --fresh
+
 mkdir -p /config/tailscale/systemd/tailscaled.service.d
 mkdir -p /config/tailscale/state
 


### PR DESCRIPTION
Fixes #29

The steps are from https://community.ui.com/questions/Fix-Solution-Lets-Encrypt-DST-Root-CA-X3-Expiration-Problems-with-IDS-IPS-Signature-Updates-HTTPS-E/0404a626-1a77-4d6c-9b4c-17ea3dea641d

Unfortunately, Ubiquiti never provided this update to EdgeRouter firmware.

### Test Plan

I re-installed Tailscale on my ER-4 using this updated script. I have also verified that the added lines are idempotent.